### PR TITLE
Remove strict angular dependency in favor of `~`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,6 +34,6 @@
     "url": "git://github.com/jvandemo/angular-growl-notifications.git"
   },
   "dependencies": {
-    "angular": "1.2.22"
+    "angular": "~1.2.22"
   }
 }


### PR DESCRIPTION
I've been using this package with angular `1.2.26` for a while now and haven't noticed any weirdness, I think having a strict version requirement is also a little to restrictive and forces people to put in a (seemingly) unnecessary resolve in their integrations.
