### PR TITLE
fix(directive): releasing $timeout on remove()

### DIFF
--- a/src/growlNotifications/directives/growlNotification.js
+++ b/src/growlNotifications/directives/growlNotification.js
@@ -80,7 +80,7 @@
    * @param $attrs
    * @param $scope
    */
-  function growlNotificationController($element, $animate, $attrs, $scope) {
+  function growlNotificationController($element, $animate, $attrs, $scope, $timeout) {
 
     /**
      * Placeholder for timer promise
@@ -96,8 +96,8 @@
       $animate.leave($element);
 
       // Cancel scheduled automatic removal if there is one
-      if (this.timer && this.timer.cancel) {
-        this.timer.cancel();
+      if (this.timer) {
+        $timeout.cancel(this.timer);
 
         // Run onClose handler if there is one
         if($attrs.onClose){
@@ -109,7 +109,7 @@
   }
 
   // Inject dependencies
-  growlNotificationController.$inject = ['$element', '$animate', '$attrs', '$scope'];
+  growlNotificationController.$inject = ['$element', '$animate', '$attrs', '$scope', '$timeout'];
 
   // Export
   angular


### PR DESCRIPTION
This commit uses the Angular $timeout service to clear the timer (set by the growl directives link method) when the `$growlNotification.remove()` method is called. Ensuring this removal propagates and is respected by Angular's digest loop.

**Solution:**
Replace 
```js
this.timer.cancel()
``` 
with 
```js
$timeout.cancel(this.timer)
```
to ensure the timer is cleaned up within Angular.

**Problem:**
When testing an Angular application with [Protractor](https://github.com/angular/protractor) there is a default configuration `ignoreSynchronization` that is set to false - this means that Protractor will watch Angular's services `$http`, `$timeout` etc. and wait until promises are resolved before continuing the test. In the current implementation the $timeout set in the directive 
```js
ctrl.timer = $timeout(//...
```

is never actually cleared when `$growlNotification.remove()` is called - this means end to end tests will wait until the `ttl` has been completed and the `$timeout` is cleaned up automatically (it is worth noting the call to `$animate` works fine so it actually looks like the notification is removed!).